### PR TITLE
Copy autograde.sh to image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,8 @@ RUN pip3 install git+https://github.com/cs50/submit50@classroom
 # Copy files to image
 COPY ./etc /etc
 COPY ./opt /opt
+COPY ./autograde.sh /
+RUN chmod a+rx /autograde.sh
 RUN chmod a+rx /opt/cs50/bin/*
 
 


### PR DESCRIPTION
Currently getting errors when running check:

`docker: Error response from daemon: OCI runtime create failed: container_linux.go:380: starting container process caused: exec: "/autograde.sh": stat /autograde.sh: no such file or directory: unknown.`

Probably because `autograde.sh` is not copied over to the image?