### PR TITLE
Setting TZ in removeEnv (so that it's picked up by VS Code extensions) rather than codespace.sh

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -25,6 +25,9 @@
     ],
     "image": "ghcr.io/cs50/codespace",
     "postCreateCommand": "/opt/cs50/bin/postCreateCommand",
+    "remoteEnv": { 
+        "TZ": "${localEnv:CS50_TZ}"
+    },
     "settings": {
         "breadcrumbs.enabled": false,
         "C_Cpp.autocomplete": "Disabled",

--- a/etc/profile.d/codespace.sh
+++ b/etc/profile.d/codespace.sh
@@ -70,10 +70,4 @@ if [ "$(whoami)" != "root" ]; then
     #
     # This resolves invisible GUI elements issues in noVNC
     export JAVA_TOOL_OPTIONS="-Dsun.java2d.opengl=true"
-
-    # Set time zone using Codespaces user secret
-    # https://docs.github.com/en/rest/codespaces/secrets
-    if [[ ! -z "$CS50_TZ" ]]; then
-        export TZ="$CS50_TZ"
-    fi
 fi


### PR DESCRIPTION
E.g., for GitDoc's commit timestamps.