### PR TITLE
Checks for `CS50_TOKEN` explicitly, then falls back on `GITHUB_TOKEN`

### DIFF
--- a/opt/cs50/bin/gitcredential_github.sh
+++ b/opt/cs50/bin/gitcredential_github.sh
@@ -1,6 +1,10 @@
-#!/bin/sh
+#!/bin/bash
 echo protocol=https
 echo host=github.com
 echo path=
 echo username=PersonalAccessToken
-echo password=$CS50_TOKEN
+if [[ ! -z "$CS50_TOKEN" ]]; then
+    echo password="$CS50_TOKEN"
+else
+    echo password="$GITHUB_TOKEN"
+fi


### PR DESCRIPTION
Fixes #78.