### PR TITLE
Updates `cd` alias to avoid race condition

### DIFF
--- a/etc/profile.d/codespace.sh
+++ b/etc/profile.d/codespace.sh
@@ -32,7 +32,7 @@ if [ "$(whoami)" != "root" ]; then
     alias bfg="java -jar /opt/share/bfg-1.14.0.jar"
 
     # Configure cd to default to workspace
-    alias cd="HOME=\"$CODESPACE_VSCODE_FOLDER\" cd"
+    alias cd="HOME=\"/workspaces/$RepositoryName\" cd"
 
     # Rewrite URL in stderr
     # https://stackoverflow.com/a/52575087/5156190

--- a/opt/cs50/bin/code
+++ b/opt/cs50/bin/code
@@ -53,6 +53,14 @@ if [ "$options" = false ]; then
                 fi
             fi
 
+            # If file doesn't have an extension
+            if [[ ! "$arg" =~ \.[^.]+$ ]]; then
+                read -p "Are you sure you want to create $(tput bold)$arg$(tput sgr0)? Filenames usually have extensions. [y/N] " -r
+                if [[ ! "${REPLY,,}" =~ ^y|yes$ ]]; then
+                    exit 1
+                fi
+            fi
+
             # If file extension is capitalized
             if [[ "$arg" =~ \.[A-Z]+$ ]]; then
                 read -p "Are you sure you want to create $(tput bold)$arg$(tput sgr0)? File extensions aren't usually capitalized. [y/N] " -r


### PR DESCRIPTION
Seems `CODESPACE_VSCODE_FOLDER` is set client-side, which results in a race condition whereby

```
alias cd="HOME=\"$CODESPACE_VSCODE_FOLDER\" cd"
```

sometimes results in an empty string for `$CODESPACE_VSCODE_FOLDER`. By contrast, `$RepositoryName` is set server-side in `/etc/environment`.