### PR TITLE
Disables `html.autoCreateQuotes`

### DIFF
--- a/devcontainer.json
+++ b/devcontainer.json
@@ -119,6 +119,7 @@
                 "gitdoc.commitMessageFormat": "ccc, LLL d, kkkk, h:mm a ZZ",
                 "gitdoc.commitValidationLevel": "none",
                 "gitdoc.pullOnOpen": false,
+                "html.autoCreateQuotes": false,
                 "html.format.indentInnerHtml": true,
                 "html.suggest.html5": false,
                 "java.server.launchMode": "Standard",


### PR DESCRIPTION
UX isn't ideal otherwise, as in lecture, whereby:

* Opening a quote yourself results in `""` with cursor after close quote.
* Closing quote yourself results in `"...""`.