### PR TITLE
Added in "editor.mouseWheelZoom": true

### DIFF
--- a/devcontainer.json
+++ b/devcontainer.json
@@ -69,10 +69,11 @@
                 "editor.formatOnSave": false,
                 "editor.guides.indentation": false,
                 "editor.hover.enabled": false,
-                "editor.lightbulb.enabled": false,
+                "editor.lightbulb.enabled":"off",
                 "editor.matchBrackets": "never",
+                "editor.mouseWheelZoom": true,
                 "editor.minimap.enabled": false,
-                "editor.occurrencesHighlight": false,
+                "editor.occurrencesHighlight":"off",
                 "editor.parameterHints.enabled": false,
                 "editor.quickSuggestions": {
                     "other": "off",

--- a/devcontainer.json
+++ b/devcontainer.json
@@ -69,11 +69,11 @@
                 "editor.formatOnSave": false,
                 "editor.guides.indentation": false,
                 "editor.hover.enabled": false,
-                "editor.lightbulb.enabled":"off",
+                "editor.lightbulb.enabled": "off",
                 "editor.matchBrackets": "never",
                 "editor.mouseWheelZoom": true,
                 "editor.minimap.enabled": false,
-                "editor.occurrencesHighlight":"off",
+                "editor.occurrencesHighlight": "off",
                 "editor.parameterHints.enabled": false,
                 "editor.quickSuggestions": {
                     "other": "off",


### PR DESCRIPTION
Added in "editor.mouseWheelZoom": true, so students with visual impairments can easily change the font size by just scrolling the wheel.

Also fixed 2 settings that have changes from "false" to "off".