### PR TITLE
Persists user's own `rstudio-prefs.json`

### DIFF
--- a/opt/cs50/bin/rstudio
+++ b/opt/cs50/bin/rstudio
@@ -46,6 +46,9 @@ fi
 # Pull latest image
 docker pull "$IMAGE"
 
+# Ensure preferences exist
+touch "/workspaces/$RepositoryName/rstudio-prefs.json"
+
 # Create container
 # https://rocker-project.org/images/versioned/rstudio.html#environment-variables
 docker create \
@@ -57,6 +60,7 @@ docker create \
     --publish 8787:8787 \
     --rm \
     --volume "$LOCAL_WORKSPACE_FOLDER":"/workspaces/$RepositoryName" \
+    --volume "/workspaces/$RepositoryName/rstudio-prefs.json":/home/rstudio/.config/rstudio/rstudio-prefs.json \
     "$IMAGE" > /dev/null
 
 # Customize rstudio-prefs.json


### PR DESCRIPTION
@rongxin-liu, what do you think is best here? I'm currently persisting user prefs to (1), but would (2) or (3) perhaps be best?

1. `/workspaces/$RepositoryName/rstudio-prefs.json`, in which case it appears in file explorer
2. `/workspaces/$RepositoryName/.config/rstudio/rstudio-prefs.json`, similar to where it ends up in `rstudio` container, but won't be backed up (at the moment) via GitDoc, since it'd be in a dotfolder
3. `/home/ubuntu/.config/rstudio/rstudio-prefs.json`, more similar to where it ends up in `rstudio` container, but it wouldn't persist after rebuilds either
4. other...