### PR TITLE
Hides Layout Controls by default

### DIFF
--- a/devcontainer.json
+++ b/devcontainer.json
@@ -215,6 +215,7 @@
                 "workbench.editor.closeOnFileDelete": true,
                 "workbench.editor.enablePreview": false,
                 "workbench.iconTheme": "vs-minimal", /* Simplify icons */
+                "workbench.layoutControl.enabled": false,
                 "workbench.preferredDarkColorTheme": "GitHub Dark Default",
                 "workbench.preferredLightColorTheme": "GitHub Light Default",
                 "workbench.startupEditor": "none",


### PR DESCRIPTION
Reloading page restores our own layout anyway, and takes up vertical space.

![Screenshot 2024-10-05 at 9 47 31 PM](https://github.com/user-attachments/assets/499e8575-147a-4926-8070-2d729b1a2947)
