### PR TITLE
Sets `workbench.editor.labelFormat` to `"medium"` so that students see which directory a file is in

### DIFF
--- a/devcontainer.json
+++ b/devcontainer.json
@@ -216,6 +216,7 @@
                 },
                 "workbench.editor.closeOnFileDelete": true,
                 "workbench.editor.enablePreview": false,
+                "workbench.editor.labelFormat": "medium",
                 "workbench.iconTheme": "vs-minimal", /* Simplify icons */
                 "workbench.layoutControl.enabled": false,
                 "workbench.preferredDarkColorTheme": "GitHub Dark Default",


### PR DESCRIPTION
Particularly to help with situations in which students (accidentally) have identically named files:

<img width="480" alt="Screenshot 2025-06-10 at 9 11 21 AM" src="https://github.com/user-attachments/assets/874a56f6-a3da-441f-a6e7-5f529ce20053" />
