### PR TITLE
Fix #170: Update pydantic to >=2.8.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -157,9 +157,10 @@ RUN pip3 install --no-cache-dir \
         inflect==7.0.0 \
         matplotlib \
         pillow==10.4.0 \
-        "pydantic<2" \
+        pydantic>=2.8.0 \
         pytz \
         setuptools
+
 
 
 # Copy files to image


### PR DESCRIPTION
This pull request fixes Issue #170 by updating the `pydantic` dependency from `<2` to `>=2.8.0` in the Dockerfile.

- Updated the pip install line to use the latest version
- Verified the change locally for correctness
- Ready for review

cc @rongxin-liu 
