### PR TITLE
refactor: update deprecated JS/TS settings

### DIFF
--- a/devcontainer.json
+++ b/devcontainer.json
@@ -145,9 +145,9 @@
                 ],
                 "java.inlayHints.parameterNames.enabled": "none",
                 "java.debug.settings.enableRunDebugCodeLens": false,
-                "javascript.format.insertSpaceAfterFunctionKeywordForAnonymousFunctions": false,
-                "javascript.suggest.enabled": false,
-                "javascript.validate.enable": false, /* Disable red squiggles */
+                "js/ts.format.insertSpaceAfterFunctionKeywordForAnonymousFunctions": false,
+                "js/ts.suggest.enabled": false,
+                "js/ts.validate.enabled": false, /* Disable red squiggles */
                 "Prettier-SQL.keywordCase": "upper",
                 "problems.decorations.enabled": false,
                 "problems.visibility": false,


### PR DESCRIPTION
The following settings deprecated since [version 1.110](https://code.visualstudio.com/updates/v1_110#_unified-javascript-and-typescript-settings) have been updated:
- `javascript.format.insertSpaceAfterFunctionKeywordForAnonymousFunctions`
- `javascript.suggest.enabled`
- `javascript.validate.enable`