### PR TITLE
fix: update editor.hover.enabled to use string value

### DIFF
--- a/devcontainer.json
+++ b/devcontainer.json
@@ -70,7 +70,7 @@
                 "editor.foldingHighlight": false,
                 "editor.formatOnSave": false,
                 "editor.guides.indentation": false,
-                "editor.hover.enabled": false,
+                "editor.hover.enabled": "off",
                 "editor.lightbulb.enabled": "off",
                 "editor.matchBrackets": "never",
                 "editor.mouseWheelZoom": true,


### PR DESCRIPTION
The `editor.hover.enabled` setting has been updated from `false` to `"off"` to match the expected type and valid options (`"on"`, `"off"`, `"onKeyboardModifier"`) since [version 1.107](https://code.visualstudio.com/updates/v1_107#_on-demand-editor-hover-popups).